### PR TITLE
arrayDif -> arrayDiff in array:difference()

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/cfc_lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cfc_lib.lua
@@ -69,7 +69,7 @@ end
 e2function array array:difference(array arrayDiff)
     local difference = {}
     for _, v in pairs( this ) do
-        if !table.KeyFromValue( arrayDif, v ) then difference << v end
+        if !table.KeyFromValue( arrayDiff, v ) then difference << v end
     end
 
     return difference


### PR DESCRIPTION
Just a simple typo that I found while looking through CFC projects.