### PR TITLE
add stuff where they are supposed to

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/cfc_number.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cfc_number.lua
@@ -1,0 +1,1 @@
+CFCE2Lib.RegisterExtension( "cfc_e2_lib", true )

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_cfc_e2_lib.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_cfc_e2_lib.lua
@@ -1,3 +1,5 @@
+CFCE2Lib.RegisterExtension( "cfc_e2_lib", true )
+
 -- PvP Functions
 E2Helper.Descriptions["playerIsInPvp(e:)"]     = "Returns 1 if a player is in Pvp, and 0 otherwise."
 E2Helper.Descriptions["playerIsInBuild(e:)"]   = "Returns 1 if a player is in build, and 0 otherwise."


### PR DESCRIPTION
At the top of cfc_number.lua, it isnt registered, and always says 'cfc_number.lua' is missing in console when i do things. I also put it at the top of cl_cfc_e2_lib.lua because why not?