### PR TITLE
Fixed some issues with ejectPodTo

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/cfc_entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cfc_entity.lua
@@ -46,9 +46,9 @@ e2function void entity:ejectPodTo( vector pos )
     local clampedPos = clamp( pos )
 
     local seatPos = this:GetPos()
-    local x = math.clamp( clampedPos.x, seatPos.x - ejectRange, seatPos.x + ejectRange)
-    local y = math.clamp( clampedPos.y, seatPos.y - ejectRange, seatPos.y + ejectRange)
-    local z = math.clamp( clampedPos.z, seatPos.z - ejectRange, seatPos.z + ejectRange)
+    local x = math.clamp( clampedPos[1], seatPos[1] - ejectRange, seatPos[1] + ejectRange)
+    local y = math.clamp( clampedPos[2], seatPos[2] - ejectRange, seatPos[2] + ejectRange)
+    local z = math.clamp( clampedPos[3], seatPos[3] - ejectRange, seatPos[3] + ejectRange)
     clampedPos = Vector(x, y, z)
 
     if not IsValid( this ) or not this:IsVehicle() then return end

--- a/lua/entities/gmod_wire_expression2/core/custom/cfc_entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cfc_entity.lua
@@ -41,8 +41,15 @@ e2function number entity:isInFaction()
 end
 
 -- Vehicle Entities
+local ejectRange = 500
 e2function void entity:ejectPodTo( vector pos )
     local clampedPos = clamp( pos )
+
+    local seatPos = this:GetPos()
+    local x = math.clamp( clampedPos.x, seatPos.x - ejectRange, seatPos.x + ejectRange)
+    local y = math.clamp( clampedPos.y, seatPos.y - ejectRange, seatPos.y + ejectRange)
+    local z = math.clamp( clampedPos.z, seatPos.z - ejectRange, seatPos.z + ejectRange)
+    clampedPos = Vector(x, y, z)
 
     if not IsValid( this ) or not this:IsVehicle() then return end
     if this:CPPIGetOwner() ~= self.player then return end

--- a/lua/entities/gmod_wire_expression2/core/custom/cfc_entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cfc_entity.lua
@@ -45,7 +45,7 @@ e2function void entity:ejectPodTo( vector pos )
     local clampedPos = clamp( pos )
 
     if not IsValid( this ) or not this:IsVehicle() then return end
-    if not this:CPPIGetOwner() == self.player then return end
+    if this:CPPIGetOwner() ~= self.player then return end
 
     local driver = this:GetDriver()
     if not IsValid( driver ) or not driver:IsPlayer() then return end

--- a/lua/entities/gmod_wire_expression2/core/custom/cfc_entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cfc_entity.lua
@@ -43,7 +43,8 @@ end
 -- Vehicle Entities
 local ejectRange = 500
 e2function void entity:ejectPodTo( vector pos )
-    local clampedPos = clamp( pos )
+    local posVec = Vector( pos[1], pos[2], pos[3] )
+    local clampedPos = clamp( posVec )
 
     local seatPos = this:GetPos()
     local x = math.Clamp( clampedPos[1], seatPos[1] - ejectRange, seatPos[1] + ejectRange)

--- a/lua/entities/gmod_wire_expression2/core/custom/cfc_entity.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cfc_entity.lua
@@ -46,9 +46,9 @@ e2function void entity:ejectPodTo( vector pos )
     local clampedPos = clamp( pos )
 
     local seatPos = this:GetPos()
-    local x = math.clamp( clampedPos[1], seatPos[1] - ejectRange, seatPos[1] + ejectRange)
-    local y = math.clamp( clampedPos[2], seatPos[2] - ejectRange, seatPos[2] + ejectRange)
-    local z = math.clamp( clampedPos[3], seatPos[3] - ejectRange, seatPos[3] + ejectRange)
+    local x = math.Clamp( clampedPos[1], seatPos[1] - ejectRange, seatPos[1] + ejectRange)
+    local y = math.Clamp( clampedPos[2], seatPos[2] - ejectRange, seatPos[2] + ejectRange)
+    local z = math.Clamp( clampedPos[3], seatPos[3] - ejectRange, seatPos[3] + ejectRange)
     clampedPos = Vector(x, y, z)
 
     if not IsValid( this ) or not this:IsVehicle() then return end


### PR DESCRIPTION
The logic issue allowed for some unwanted behaviour.
The clamp will prevent this being an op teleport alternative. The range is set to 500, but could probably be edited to whatever number the _wire_pod_exit_distance_ convar is set to by anyone with access to read that.